### PR TITLE
fix(fw): fill verkle genesis with input vkt

### DIFF
--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -18,7 +18,6 @@ from ethereum_test_base_types import (
     HeaderNonce,
     HexNumber,
     Number,
-    to_json,
 )
 from ethereum_test_exceptions import BlockException, EngineAPIError, TransactionException
 from ethereum_test_fixtures import BaseFixture, FixtureFormats
@@ -436,7 +435,7 @@ class BlockchainTest(BaseTest):
             txs=txs,
             env=env,
             fork=fork,
-            vkt=to_json(previous_vkt) if previous_vkt is not None else None,
+            vkt=previous_vkt,
             chain_id=self.chain_id,
             reward=fork.get_reward(env.number, env.timestamp),
             eips=eips,
@@ -556,7 +555,7 @@ class BlockchainTest(BaseTest):
         Verifies the post state after all block/s or payload/s are generated.
         """
         try:
-            if env.verkle_conversion_started:
+            if env.verkle_conversion_started or env.verkle_conversion_ended:
                 if vkt is not None:
                     pass  # TODO: skip exact account verify checks
                     # verify_post_vkt(t8n=t8n, expected_post=self.post, got_vkt=vkt)
@@ -585,6 +584,13 @@ class BlockchainTest(BaseTest):
         env = environment_from_parent_header(genesis.header)
         head = genesis.header.block_hash
         vkt: Optional[VerkleTree] = None
+
+        # Filling for verkle genesis tests
+        if fork is Verkle:
+            env.verkle_conversion_ended = True
+            # convert alloc to vkt
+            vkt = t8n.from_mpt_to_vkt(alloc)
+            alloc = Alloc()
 
         # Hack for filling naive verkle transition tests
         if fork is EIP6800Transition:

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from itertools import groupby
 from pathlib import Path
 from re import Pattern
-from typing import Any, Dict, List, Mapping, Optional, Type
+from typing import Dict, List, Mapping, Optional, Type
 
 from ethereum_test_fixtures import FixtureFormats, FixtureVerifier
 from ethereum_test_forks import Fork
@@ -248,9 +248,9 @@ class TransitionTool(FixtureVerifier):
         txs: List[Transaction]
         env: Environment
         fork_name: str
-        vkt: Any = None
         chain_id: int = field(default=1)
         reward: int = field(default=0)
+        vkt: Optional[VerkleTree] = None
 
         def to_input(self) -> TransitionToolInput:
             """
@@ -514,9 +514,9 @@ class TransitionTool(FixtureVerifier):
         txs: List[Transaction],
         env: Environment,
         fork: Fork,
-        vkt: Any = None,
         chain_id: int = 1,
         reward: int = 0,
+        vkt: Optional[VerkleTree] = None,
         eips: Optional[List[int]] = None,
         debug_output_path: str = "",
     ) -> TransitionToolOutput:


### PR DESCRIPTION
## 🗒️ Description
Small hack to fill verkle genesis tests starting with an `input/vkt.json` where `input/alloc.json` is empty.

Fixes the input enviroment by setting `conversionEnded == True` when the fill fork is Verkle.

Note we get errors of the following now:
```
Exception: tx unexpectedly failed: insufficient funds for gas * price + value: address 0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B have 0 want 1000000000
```

I'm fairly confident once we align geth to accept the `input/vkt.json` this should fill correctly.