### PR TITLE
feat(fw): verkle genesis state root subcommand

### DIFF
--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -346,11 +346,14 @@ class BlockchainTest(BaseTest):
         )
         if empty_accounts := pre_alloc.empty_accounts():
             raise Exception(f"Empty accounts in pre state: {empty_accounts}")
+
         state_root: bytes
-        if fork < Verkle:
+        # TODO: refine, currently uses `evm verkle state-root` to get this.
+        if fork < Verkle or fork is EIP6800Transition:
             state_root = pre_alloc.state_root()
-        else:  # TODO: refine, currently uses `evm verkle state-root` to get this.
+        else:
             state_root = t8n.get_verkle_state_root(mpt_alloc=pre_alloc)
+
         genesis = FixtureHeader(
             parent_hash=0,
             ommers_hash=EmptyOmmersRoot,

--- a/src/evm_transition_tool/geth.py
+++ b/src/evm_transition_tool/geth.py
@@ -2,6 +2,7 @@
 Go-ethereum Transition tool interface.
 """
 
+import binascii
 import json
 import os
 import shutil
@@ -177,7 +178,8 @@ class GethTransitionTool(TransitionTool):
                     f"Failed to run verkle subcommand: '{' '.join(command)}'. "
                     f"Error: '{result.stderr.decode()}'"
                 )
-            return bytes(json.loads(result.stdout.decode()))
+            hex_string = result.stdout.decode().strip()
+            return binascii.unhexlify(hex_string[2:])
 
     def from_mpt_to_vkt(self, mpt_alloc: Alloc) -> VerkleTree:
         """

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -568,6 +568,17 @@ class TransitionTool(FixtureVerifier):
             "The `verify_fixture()` function is not supported by this tool. Use geth's evm tool."
         )
 
+    def get_verkle_state_root(self, mpt_alloc: Alloc) -> bytes:
+        """
+        Returns the VKT state root of from an input MPT.
+
+        Currently only implemented by geth's evm.
+        """
+        raise NotImplementedError(
+            "The `get_verkle_state_root` function is not supported by this tool. Use geth's evm "
+            "tool."
+        )
+
     def from_mpt_to_vkt(self, mpt_alloc: Alloc) -> VerkleTree:
         """
         Returns the verkle tree representation for an entire MPT alloc using the verkle subcommand.


### PR DESCRIPTION
## 🗒️ Description

Uses t8n `evm verkle state-root` sub-command to generate the genesis state root for Verkle genesis tests. Previously this was incorrect.
