### PR TITLE
feat(fw): add pre alloc to t8n input alongside vkt. (2 inputs)

### DIFF
--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -598,7 +598,6 @@ class BlockchainTest(BaseTest):
             env.verkle_conversion_ended = True
             # convert alloc to vkt
             vkt = t8n.from_mpt_to_vkt(alloc)
-            alloc = Alloc()
 
         # Hack for filling naive verkle transition tests
         if fork is EIP6800Transition:


### PR DESCRIPTION
## 🗒️ Description
As discussed we need the pre alloc (MPT) code for filling with geth due to the flat-db.

This is option 1.

t8n recieves both:
- `input/alloc.json`
- `input/vkt.json`
